### PR TITLE
Remove trailing comma

### DIFF
--- a/Build System/Promela - Random.sublime-build
+++ b/Build System/Promela - Random.sublime-build
@@ -4,6 +4,6 @@
 
 	"windows":
     {
-        "cmd": "C:\\jspin\\bin\\spin.exe -X -u250 \"$file\"",
+        "cmd": "C:\\jspin\\bin\\spin.exe -X -u250 \"$file\""
     }
 }


### PR DESCRIPTION
Trailing comma was making Sublime 2 raise errors when trying to build a program.
