### PR TITLE
Add Syntaxes/Comments.tmPreferences to enable "Toggle Comments".

### DIFF
--- a/Syntaxes/Comments.tmPreferences
+++ b/Syntaxes/Comments.tmPreferences
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Comments</string>
+	<key>scope</key>
+	<string>source.promela</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START_2</string>
+				<key>value</key>
+				<string>/*</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_END_2</string>
+				<key>value</key>
+				<string>*/</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string>// </string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
This file allows the user to toggle comments in Promela files, using
e.g. ctlr+/ (for line comments) and ctrl+shift+/ (for block comments).

Equivalently available via Edit > Comment > Toggle Comment.